### PR TITLE
Use null as default for volume_type

### DIFF
--- a/testbed-default/variables.tf
+++ b/testbed-default/variables.tf
@@ -29,7 +29,7 @@ variable "volume_size_storage" {
 
 variable "volume_type" {
   type    = string
-  default = "__DEFAULT__"
+  default = null
 }
 
 variable "flavor_node" {

--- a/testbed-managerless/variables.tf
+++ b/testbed-managerless/variables.tf
@@ -29,7 +29,7 @@ variable "volume_size_storage" {
 
 variable "volume_type" {
   type    = string
-  default = "__DEFAULT__"
+  default = null
 }
 
 variable "flavor_node" {


### PR DESCRIPTION
This way it also works on environments without a __DEFAULT__ volume type.