### PR TITLE
Fix "Invalid cloud-config schema: user-data"

### DIFF
--- a/testbed-default/customisations/default_custom.tf
+++ b/testbed-default/customisations/default_custom.tf
@@ -23,7 +23,7 @@ resource "openstack_compute_instance_v2" "node_server" {
 network:
    config: disabled
 mounts:
-  - [ ephemeral0, null ]
+  - [ ephemeral0 ]
 ntp:
   enabled: true
   ntp_client: chrony

--- a/testbed-managerless/customisations/default_custom.tf
+++ b/testbed-managerless/customisations/default_custom.tf
@@ -23,7 +23,7 @@ resource "openstack_compute_instance_v2" "node_server" {
 network:
    config: disabled
 mounts:
-  - [ ephemeral0, null ]
+  - [ ephemeral0 ]
 ntp:
   enabled: true
   ntp_client: chrony


### PR DESCRIPTION
Error: Cloud config schema errors: mounts.0.1: None is not of type 'string'