### PR TITLE
testbed-default: on the manager allow access on port 9091/tcp

### DIFF
--- a/testbed-default/neutron.tf
+++ b/testbed-default/neutron.tf
@@ -47,6 +47,13 @@ resource "openstack_compute_secgroup_v2" "security_group_management" {
   }
 
   rule {
+    cidr        = "192.168.16.0/20"
+    ip_protocol = "tcp"
+    from_port   = 9091
+    to_port     = 9091
+  }
+
+  rule {
     cidr        = "0.0.0.0/0"
     ip_protocol = "udp"
     from_port   = 51820


### PR DESCRIPTION
The prometheus service is running on the manager.