### PR TITLE
testbed-default: on the manager allow access on port 80/tcp & 443/tcp

### DIFF
--- a/testbed-default/neutron.tf
+++ b/testbed-default/neutron.tf
@@ -42,6 +42,20 @@ resource "openstack_compute_secgroup_v2" "security_group_management" {
   rule {
     cidr        = "192.168.16.0/20"
     ip_protocol = "tcp"
+    from_port   = 80
+    to_port     = 80
+  }
+
+  rule {
+    cidr        = "192.168.16.0/20"
+    ip_protocol = "tcp"
+    from_port   = 443
+    to_port     = 443
+  }
+
+  rule {
+    cidr        = "192.168.16.0/20"
+    ip_protocol = "tcp"
     from_port   = 3128
     to_port     = 3128
   }


### PR DESCRIPTION
The keycloak service is running on the manager.