### PR TITLE
Update secgroup resources

### DIFF
--- a/testbed-default/manager.tf
+++ b/testbed-default/manager.tf
@@ -1,7 +1,7 @@
 resource "openstack_networking_port_v2" "manager_port_management" {
   network_id = openstack_networking_network_v2.net_management.id
   security_group_ids = [
-    openstack_compute_secgroup_v2.security_group_management.id
+    openstack_networking_secgroup_v2.security_group_management.id
   ]
 
   fixed_ip {

--- a/testbed-default/neutron.tf
+++ b/testbed-default/neutron.tf
@@ -2,70 +2,82 @@
 # Security groups #
 ###################
 
-resource "openstack_compute_secgroup_v2" "security_group_node" {
+resource "openstack_networking_secgroup_v2" "security_group_node" {
   name        = "${var.prefix}-node"
   description = "node security group"
-
-  rule {
-    cidr        = "0.0.0.0/0"
-    ip_protocol = "tcp"
-    from_port   = 1
-    to_port     = 65535
-  }
-
-  rule {
-    cidr        = "0.0.0.0/0"
-    ip_protocol = "udp"
-    from_port   = 1
-    to_port     = 65535
-  }
-
-  rule {
-    cidr        = "0.0.0.0/0"
-    ip_protocol = "icmp"
-    from_port   = -1
-    to_port     = -1
-  }
 }
 
-resource "openstack_compute_secgroup_v2" "security_group_management" {
+resource "openstack_networking_secgroup_rule_v2" "security_group_node_rule1" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  remote_ip_prefix  = "0.0.0.0/0"
+  protocol          = "tcp"
+  security_group_id = openstack_networking_secgroup_v2.security_group_node.id
+}
+
+resource "openstack_networking_secgroup_rule_v2" "security_group_node_rule2" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  remote_ip_prefix  = "0.0.0.0/0"
+  protocol          = "udp"
+  security_group_id = openstack_networking_secgroup_v2.security_group_node.id
+}
+
+resource "openstack_networking_secgroup_rule_v2" "security_group_node_rule3" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  remote_ip_prefix  = "0.0.0.0/0"
+  protocol          = "icmp"
+  security_group_id = openstack_networking_secgroup_v2.security_group_node.id
+}
+
+resource "openstack_networking_secgroup_v2" "security_group_management" {
   name        = "${var.prefix}-management"
   description = "management security group"
+}
 
-  rule {
-    cidr        = "0.0.0.0/0"
-    ip_protocol = "tcp"
-    from_port   = 22
-    to_port     = 22
-  }
+resource "openstack_networking_secgroup_rule_v2" "security_group_management_rule1" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  remote_ip_prefix  = "0.0.0.0/0"
+  protocol          = "tcp"
+  port_range_min    = 22
+  port_range_max    = 22
+  security_group_id = openstack_networking_secgroup_v2.security_group_management.id
+}
 
-  rule {
-    cidr        = "0.0.0.0/0"
-    ip_protocol = "udp"
-    from_port   = 51820
-    to_port     = 51820
-  }
+resource "openstack_networking_secgroup_rule_v2" "security_group_management_rule2" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  remote_ip_prefix  = "0.0.0.0/0"
+  protocol          = "udp"
+  port_range_min    = 51820
+  port_range_max    = 51820
+  security_group_id = openstack_networking_secgroup_v2.security_group_management.id
+}
 
-  rule {
-    cidr        = "192.168.16.0/20"
-    ip_protocol = "tcp"
-    from_port   = 1
-    to_port     = 65535
-  }
+resource "openstack_networking_secgroup_rule_v2" "security_group_management_rule3" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  remote_ip_prefix  = "192.168.16.0/20"
+  protocol          = "tcp"
+  security_group_id = openstack_networking_secgroup_v2.security_group_management.id
+}
 
-  rule {
-    cidr        = "192.168.16.0/20"
-    ip_protocol = "udp"
-    from_port   = 1
-    to_port     = 65535
-  }
+resource "openstack_networking_secgroup_rule_v2" "security_group_management_rule4" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  remote_ip_prefix  = "192.168.16.0/20"
+  protocol          = "udp"
+  security_group_id = openstack_networking_secgroup_v2.security_group_management.id
+}
 
-  rule {
-    cidr        = "0.0.0.0/0"
-    ip_protocol = "icmp"
-    from_port   = -1
-    to_port     = -1
-  }
+resource "openstack_networking_secgroup_rule_v2" "security_group_management_rule5" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  remote_ip_prefix  = "0.0.0.0/0"
+  protocol          = "icmp"
+  security_group_id = openstack_networking_secgroup_v2.security_group_management.id
 }
 
 resource "openstack_networking_secgroup_rule_v2" "security_group_rule_vrrp" {
@@ -73,7 +85,7 @@ resource "openstack_networking_secgroup_rule_v2" "security_group_rule_vrrp" {
   ethertype         = "IPv4"
   protocol          = "112" # vrrp
   remote_ip_prefix  = "0.0.0.0/0"
-  security_group_id = openstack_compute_secgroup_v2.security_group_node.id
+  security_group_id = openstack_networking_secgroup_v2.security_group_node.id
 }
 
 ############

--- a/testbed-default/nodes.tf
+++ b/testbed-default/nodes.tf
@@ -1,7 +1,7 @@
 resource "openstack_networking_port_v2" "node_port_management" {
   count              = var.number_of_nodes
   network_id         = openstack_networking_network_v2.net_management.id
-  security_group_ids = [openstack_compute_secgroup_v2.security_group_node.id]
+  security_group_ids = [openstack_networking_secgroup_v2.security_group_node.id]
 
   fixed_ip {
     ip_address = "192.168.16.1${count.index}"

--- a/testbed-managerless/neutron.tf
+++ b/testbed-managerless/neutron.tf
@@ -2,30 +2,33 @@
 # Security groups #
 ###################
 
-resource "openstack_compute_secgroup_v2" "security_group_node" {
+resource "openstack_networking_secgroup_v2" "security_group_node" {
   name        = "${var.prefix}-node"
   description = "node security group"
+}
 
-  rule {
-    cidr        = "0.0.0.0/0"
-    ip_protocol = "tcp"
-    from_port   = 1
-    to_port     = 65535
-  }
+resource "openstack_networking_secgroup_rule_v2" "security_group_rule_vrrp" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = openstack_networking_secgroup_v2.security_group_node.id
+}
 
-  rule {
-    cidr        = "0.0.0.0/0"
-    ip_protocol = "udp"
-    from_port   = 1
-    to_port     = 65535
-  }
+resource "openstack_networking_secgroup_rule_v2" "security_group_rule_vrrp" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "udp"
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = openstack_networking_secgroup_v2.security_group_node.id
+}
 
-  rule {
-    cidr        = "0.0.0.0/0"
-    ip_protocol = "icmp"
-    from_port   = -1
-    to_port     = -1
-  }
+resource "openstack_networking_secgroup_rule_v2" "security_group_rule_vrrp" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "icmp"
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = openstack_networking_secgroup_v2.security_group_node.id
 }
 
 resource "openstack_networking_secgroup_rule_v2" "security_group_rule_vrrp" {
@@ -33,7 +36,7 @@ resource "openstack_networking_secgroup_rule_v2" "security_group_rule_vrrp" {
   ethertype         = "IPv4"
   protocol          = "112" # vrrp
   remote_ip_prefix  = "0.0.0.0/0"
-  security_group_id = openstack_compute_secgroup_v2.security_group_node.id
+  security_group_id = openstack_networking_secgroup_v2.security_group_node.id
 }
 
 ############

--- a/testbed-managerless/nodes.tf
+++ b/testbed-managerless/nodes.tf
@@ -1,7 +1,7 @@
 resource "openstack_networking_port_v2" "node_port_management" {
   count              = var.number_of_nodes
   network_id         = openstack_networking_network_v2.net_management.id
-  security_group_ids = [openstack_compute_secgroup_v2.security_group_node.id]
+  security_group_ids = [openstack_networking_secgroup_v2.security_group_node.id]
 
   fixed_ip {
     ip_address = "192.168.16.1${count.index}"


### PR DESCRIPTION
Using the compute API for security groups is deprecated, switch to using the networking API instead.