### PR TITLE
Do not recreate instances on changes of `image_id`

### DIFF
--- a/testbed-default/data.tf
+++ b/testbed-default/data.tf
@@ -2,12 +2,22 @@ data "openstack_networking_network_v2" "public" {
   name = var.public
 }
 
+resource "terraform_data" "image" {
+  # Resource to trigger changes on var.image
+  input = var.image
+}
+
 data "openstack_images_image_v2" "image" {
-  name        = var.image
+  name        = terraform_data.image.output
   most_recent = true
 }
 
+resource "terraform_data" "image_node" {
+  # Resource to trigger changes on var.image_node
+  input = var.image_node
+}
+
 data "openstack_images_image_v2" "image_node" {
-  name        = var.image_node
+  name        = terraform_data.image_node.output
   most_recent = true
 }

--- a/testbed-default/manager.tf
+++ b/testbed-default/manager.tf
@@ -25,6 +25,20 @@ resource "openstack_blockstorage_volume_v3" "manager_base_volume" {
   size              = var.volume_size_base
   availability_zone = var.volume_availability_zone
   volume_type       = var.volume_type
+
+  lifecycle {
+    ignore_changes = [
+      # When specifying images by name, their ID might change when they
+      # are updated.
+      # Replacing the whole environment in this case is probably not
+      # what is expected by the user
+      image_id,
+    ]
+    replace_triggered_by = [
+      # Explicitly changing the image should trigger recreation
+      terraform_data.image
+    ]
+  }
 }
 
 resource "openstack_compute_instance_v2" "manager_server" {
@@ -37,6 +51,19 @@ resource "openstack_compute_instance_v2" "manager_server" {
   depends_on = [
     null_resource.node_semaphore
   ]
+
+  lifecycle {
+    ignore_changes = [
+      # When specifying images by name, their ID might change when they
+      # are updated.
+      # Replacing the whole environment in this case is probably not
+      # what is expected by the user
+      image_id,
+    ]
+    replace_triggered_by = [
+      terraform_data.image
+    ]
+  }
 
   network { port = openstack_networking_port_v2.manager_port_management.id }
 

--- a/testbed-default/nodes.tf
+++ b/testbed-default/nodes.tf
@@ -32,4 +32,18 @@ resource "openstack_blockstorage_volume_v3" "node_base_volume" {
   size              = var.volume_size_base
   availability_zone = var.volume_availability_zone
   volume_type       = var.volume_type
+
+  lifecycle {
+    ignore_changes = [
+      # When specifying images by name, their ID might change when they
+      # are updated.
+      # Replacing the whole environment in this case is probably not
+      # what is expected by the user
+      image_id,
+    ]
+    replace_triggered_by = [
+      # Explicitly changing the image should trigger recreation
+      terraform_data.image_node
+    ]
+  }
 }

--- a/testbed-managerless/data.tf
+++ b/testbed-managerless/data.tf
@@ -2,12 +2,22 @@ data "openstack_networking_network_v2" "public" {
   name = var.public
 }
 
+resource "terraform_data" "image" {
+  # Resource to trigger changes on var.image
+  input = var.image
+}
+
 data "openstack_images_image_v2" "image" {
-  name        = var.image
+  name        = terraform_data.image.output
   most_recent = true
 }
 
+resource "terraform_data" "image_node" {
+  # Resource to trigger changes on var.image_node
+  input = var.image_node
+}
+
 data "openstack_images_image_v2" "image_node" {
-  name        = var.image_node
+  name        = terraform_data.image_node.output
   most_recent = true
 }

--- a/testbed-managerless/nodes.tf
+++ b/testbed-managerless/nodes.tf
@@ -28,4 +28,18 @@ resource "openstack_blockstorage_volume_v3" "node_base_volume" {
   size              = var.volume_size_base
   availability_zone = var.volume_availability_zone
   volume_type       = var.volume_type
+
+  lifecycle {
+    ignore_changes = [
+      # When specifying images by name, their ID might change when they
+      # are updated.
+      # Replacing the whole environment in this case is probably not
+      # what is expected by the user
+      image_id,
+    ]
+    replace_triggered_by = [
+      # Explicitly changing the image should trigger recreation
+      terraform_data.image_node
+    ]
+  }
 }


### PR DESCRIPTION
When referencing images by name outside the scope of the project, the usual expectation is to not recreate resources when any of the attributes change. E.g. when a cloud operator uploads new versions, thus creating new IDs.
Changes to `image_id` should therefore be ignored and resource replcement should be triggered only on explicit changes to the referenced image name.