### PR TITLE
On OTC add GNUTLS_CPUID_OVERRIDE to /etc/environment

### DIFF
--- a/testbed-default/manager.tf
+++ b/testbed-default/manager.tf
@@ -57,6 +57,10 @@ write_files:
       touch /var/lib/apt/periodic/update-success-stamp
       echo 'network: {config: disabled}' > /etc/cloud/cloud.cfg.d/99-disable-network-config.cfg
       chown -R ubuntu:ubuntu /home/ubuntu
+
+      if [[ -e /etc/OTC_region ]]; then
+          echo 'GNUTLS_CPUID_OVERRIDE=0x1' >> /etc/environment
+      fi
     path: /usr/local/bin/osism-testbed.sh
     permissions: '0755'
   - content: ${openstack_compute_keypair_v2.key.public_key}


### PR DESCRIPTION
Required because of this issue:

dragon@testbed-manager:~$ git clone https://github.com/osism/cfg-generics Cloning into 'cfg-generics'...
error: git-remote-https died of signal 4

https://askubuntu.com/questions/1420966/method-https-has-died-unexpectedly-sub-process-https-received-signal-4-after