### PR TITLE
testbed-default: add MANAGER_PUBLIC_IP_ADDRESS variable

### DIFF
--- a/testbed-default/manager.tf
+++ b/testbed-default/manager.tf
@@ -109,6 +109,8 @@ write_files:
       export TEMPEST=${var.tempest}
       export IS_ZUUL=${var.is_zuul}
 
+      export MANAGER_PUBLIC_IP_ADDRESS=${openstack_compute_instance_v2.manager_server.access_ip_v4}
+
     path: /opt/manager-vars.sh
     permissions: '0644'
 runcmd:


### PR DESCRIPTION
This way we know the public ip address of the manager node.