### PR TITLE
testbed-default: add external_api variable

### DIFF
--- a/testbed-default/manager.tf
+++ b/testbed-default/manager.tf
@@ -111,6 +111,7 @@ write_files:
       export IS_ZUUL=${var.is_zuul}
 
       export MANAGER_PUBLIC_IP_ADDRESS=${openstack_networking_floatingip_v2.manager_floating_ip.address}
+      export EXTERNAL_API=${var.external_api}
 
     path: /opt/manager-vars.sh
     permissions: '0644'

--- a/testbed-default/variables.tf
+++ b/testbed-default/variables.tf
@@ -126,3 +126,8 @@ variable "is_zuul" {
   type    = bool
   default = false
 }
+
+variable "external_api" {
+  type    = bool
+  default = false
+}


### PR DESCRIPTION
With the external_api parameter it is possible to make the API service reachable through the public ip address of the manager node.