### PR TITLE
Make user configurable

### DIFF
--- a/testbed-default/customisations/access_floatingip_custom.tf
+++ b/testbed-default/customisations/access_floatingip_custom.tf
@@ -12,5 +12,5 @@ resource "local_file" "MANAGER_ADDRESS" {
 resource "local_file" "inventory" {
   filename        = "inventory.${var.cloud_provider}"
   file_permission = "0644"
-  content         = "testbed-manager.testbed.osism.xyz ansible_host=${openstack_networking_floatingip_v2.manager_floating_ip.address} ansible_user=ubuntu\n"
+  content         = "testbed-manager.testbed.osism.xyz ansible_host=${openstack_networking_floatingip_v2.manager_floating_ip.address} ansible_user=${var.image_node_user}\n"
 }

--- a/testbed-default/customisations/default_custom.tf
+++ b/testbed-default/customisations/default_custom.tf
@@ -36,7 +36,7 @@ write_files:
       chronyc -a makestep
       touch /var/lib/apt/periodic/update-success-stamp
       echo 'network: {config: disabled}' > /etc/cloud/cloud.cfg.d/99-disable-network-config.cfg
-      chown -R ubuntu:ubuntu /home/ubuntu
+      chown -R ${var.image_node_user}:${var.image_node_user} /home/${var.image_node_user}
 
       if [[ -e /etc/OTC_region ]]; then
           echo 'GNUTLS_CPUID_OVERRIDE=0x1' >> /etc/environment

--- a/testbed-default/manager.tf
+++ b/testbed-default/manager.tf
@@ -84,7 +84,7 @@ write_files:
       chronyc -a makestep
       touch /var/lib/apt/periodic/update-success-stamp
       echo 'network: {config: disabled}' > /etc/cloud/cloud.cfg.d/99-disable-network-config.cfg
-      chown -R ubuntu:ubuntu /home/ubuntu
+      chown -R ${var.image_user}:${var.image_user}/home/${var.image_user}
 
       if [[ -e /etc/OTC_region ]]; then
           echo 'GNUTLS_CPUID_OVERRIDE=0x1' >> /etc/environment
@@ -92,11 +92,11 @@ write_files:
     path: /usr/local/bin/osism-testbed.sh
     permissions: '0755'
   - content: ${openstack_compute_keypair_v2.key.public_key}
-    path: /home/ubuntu/.ssh/id_rsa.pub
+    path: /home/${var.image_user}/.ssh/id_rsa.pub
     permissions: '0600'
   - content: |
       ${indent(6, openstack_compute_keypair_v2.key.private_key)}
-    path: /home/ubuntu/.ssh/id_rsa
+    path: /home/${var.image_user}/.ssh/id_rsa
     permissions: '0600'
   - content: |
       export NUMBER_OF_NODES=${var.number_of_nodes}

--- a/testbed-default/variables.tf
+++ b/testbed-default/variables.tf
@@ -17,9 +17,19 @@ variable "image" {
   default = "Ubuntu 22.04"
 }
 
+variable "image_user" {
+  type    = string
+  default = "ubuntu"
+}
+
 variable "image_node" {
   type    = string
   default = "Ubuntu 22.04"
+}
+
+variable "image_node_user" {
+  type    = string
+  default = "ubuntu"
 }
 
 variable "volume_size_base" {

--- a/testbed-managerless/customisations/access_floatingip_custom.tf
+++ b/testbed-managerless/customisations/access_floatingip_custom.tf
@@ -12,5 +12,5 @@ resource "local_file" "MANAGER_ADDRESS" {
 resource "local_file" "inventory" {
   filename        = "inventory.${var.cloud_provider}"
   file_permission = "0644"
-  content         = "testbed-manager.testbed.osism.xyz ansible_host=${openstack_networking_floatingip_v2.manager_floating_ip.address} ansible_user=ubuntu\n"
+  content         = "testbed-manager.testbed.osism.xyz ansible_host=${openstack_networking_floatingip_v2.manager_floating_ip.address} ansible_user=${var.image_node_user}\n"
 }

--- a/testbed-managerless/customisations/access_floatingip_nodes_custom.tf
+++ b/testbed-managerless/customisations/access_floatingip_nodes_custom.tf
@@ -35,8 +35,8 @@ resource "local_file" "inventory" {
   filename        = "inventory.${var.cloud_provider}"
   file_permission = "0644"
   content         = <<-EOT
-testbed-node-0.testbed.osism.xyz ansible_host=${openstack_networking_floatingip_v2.node_floating_ip[0].address} ansible_user=ubuntu
-testbed-node-1.testbed.osism.xyz ansible_host=${openstack_networking_floatingip_v2.node_floating_ip[1].address} ansible_user=ubuntu
-testbed-node-2.testbed.osism.xyz ansible_host=${openstack_networking_floatingip_v2.node_floating_ip[2].address} ansible_user=ubuntu
+testbed-node-0.testbed.osism.xyz ansible_host=${openstack_networking_floatingip_v2.node_floating_ip[0].address} ansible_user=${var.image_node_user}
+testbed-node-1.testbed.osism.xyz ansible_host=${openstack_networking_floatingip_v2.node_floating_ip[1].address} ansible_user=${var.image_node_user}
+testbed-node-2.testbed.osism.xyz ansible_host=${openstack_networking_floatingip_v2.node_floating_ip[2].address} ansible_user=${var.image_node_user}
 EOT
 }

--- a/testbed-managerless/customisations/default_custom.tf
+++ b/testbed-managerless/customisations/default_custom.tf
@@ -36,7 +36,7 @@ write_files:
       chronyc -a makestep
       touch /var/lib/apt/periodic/update-success-stamp
       echo 'network: {config: disabled}' > /etc/cloud/cloud.cfg.d/99-disable-network-config.cfg
-      chown -R ubuntu:ubuntu /home/ubuntu
+      chown -R ${var.image_node_user}:${var.image_node_user} /home/${var.image_node_user}
 
       if [[ -e /etc/OTC_region ]]; then
           echo 'GNUTLS_CPUID_OVERRIDE=0x1' >> /etc/environment

--- a/testbed-managerless/variables.tf
+++ b/testbed-managerless/variables.tf
@@ -17,9 +17,19 @@ variable "image" {
   default = "Ubuntu 22.04"
 }
 
+variable "image_user" {
+  type    = string
+  default = "ubuntu"
+}
+
 variable "image_node" {
   type    = string
   default = "Ubuntu 22.04"
+}
+
+variable "image_node_user" {
+  type    = string
+  default = "ubuntu"
 }
 
 variable "volume_size_base" {


### PR DESCRIPTION
With the image_user and image_node_user parameters it's now possible to configure the default user of the used cloud images. This way it's possible to use e.g. cento or debian as user. By default both parameters are set to ubuntu to not change the default behavior.