### PR TITLE
testbed-default: add ara variable

### DIFF
--- a/testbed-default/manager.tf
+++ b/testbed-default/manager.tf
@@ -106,6 +106,7 @@ write_files:
       export MANAGER_VERSION=${var.manager_version}
       export OPENSTACK_VERSION=${var.openstack_version}
 
+      export ARA=${var.ara}
       export REFSTACK=${var.refstack}
       export TEMPEST=${var.tempest}
       export IS_ZUUL=${var.is_zuul}

--- a/testbed-default/variables.tf
+++ b/testbed-default/variables.tf
@@ -82,6 +82,11 @@ variable "deploy_monitoring" {
   default = false
 }
 
+variable "ara" {
+  type    = bool
+  default = true
+}
+
 variable "refstack" {
   type    = bool
   default = false


### PR DESCRIPTION
With the ara variable it is possible to enable or disable the ARA service.