### PR TITLE
Add CEPH_STACK variables to enable Rook deployments (#884)

### DIFF
--- a/testbed-default/manager.tf
+++ b/testbed-default/manager.tf
@@ -117,6 +117,8 @@ write_files:
       export IMAGE_USER=${var.image_user}
       export IMAGE_NODE_USER=${var.image_node_user}
 
+      export CEPH_STACK=${var.ceph_stack}
+
     path: /opt/manager-vars.sh
     permissions: '0644'
 runcmd:

--- a/testbed-default/variables.tf
+++ b/testbed-default/variables.tf
@@ -146,3 +146,14 @@ variable "external_api" {
   type    = bool
   default = false
 }
+
+variable "ceph_stack" {
+  type    = string
+  default = "ceph-ansible"
+  validation {
+    condition = (
+      can(regex("^(ceph-ansible|rook)$", var.ceph_stack))
+    )
+    error_message = "Invalid Ceph Stack provided. Options: ceph-ansible|rook"
+  }
+}


### PR DESCRIPTION
This is part of https://github.com/osism/issues/issues/884 and needed for https://github.com/osism/testbed/pull/2274