### PR TITLE
testbed-default: fix/remove broken address pairs

### DIFF
--- a/testbed-default/manager.tf
+++ b/testbed-default/manager.tf
@@ -10,11 +10,7 @@ resource "openstack_networking_port_v2" "manager_port_management" {
   }
 
   allowed_address_pairs {
-    ip_address = "192.168.16.8/20"
-  }
-
-  allowed_address_pairs {
-    ip_address = "192.168.112.0/20"
+    ip_address = "192.168.16.8/32"
   }
 }
 

--- a/testbed-default/nodes.tf
+++ b/testbed-default/nodes.tf
@@ -9,19 +9,15 @@ resource "openstack_networking_port_v2" "node_port_management" {
   }
 
   allowed_address_pairs {
-    ip_address = "192.168.16.8/20"
+    ip_address = "192.168.16.8/32"
   }
 
   allowed_address_pairs {
-    ip_address = "192.168.16.9/20"
+    ip_address = "192.168.16.9/32"
   }
 
   allowed_address_pairs {
-    ip_address = "192.168.16.254/20"
-  }
-
-  allowed_address_pairs {
-    ip_address = "192.168.112.0/20"
+    ip_address = "192.168.16.254/32"
   }
 }
 


### PR DESCRIPTION
Required because of https://bugs.launchpad.net/neutron/+bug/2116249.