### PR TITLE
manager: drop invalid cloud-init network key

### DIFF
--- a/testbed-default/manager.tf
+++ b/testbed-default/manager.tf
@@ -66,8 +66,6 @@ resource "openstack_compute_instance_v2" "manager_server" {
 
   user_data = <<-EOT
 #cloud-config
-network:
-   config: disabled
 ntp:
   enabled: true
   ntp_client: chrony


### PR DESCRIPTION
## Summary

- Remove the top-level `network: config: disabled` stanza from the
  cloud-config user-data in `testbed-default/manager.tf`.
- Cloud-init 24.x on Ubuntu 24.04 no longer accepts `network` as a
  valid user-data module key and rejects the document during schema
  validation (`cloud-config failed schema validation!`), causing
  `cloud-init status` to exit with code 2.
- The stanza is redundant: the same user-data already disables
  cloud-init network configuration via a `runcmd` that writes
  `/etc/cloud/cloud.cfg.d/99-disable-network-config.cfg`.

## Test plan

- [ ] `make manager` provisions a manager VM on Ubuntu 24.04 / cloud-init 24.x
- [ ] `/var/log/cloud-init.log` no longer contains
      `schema.py[WARNING]: cloud-config failed schema validation!`
- [ ] `cloud-init status` exits 0 (not 2)
- [ ] `/etc/cloud/cloud.cfg.d/99-disable-network-config.cfg` is still
      written by `runcmd`, so cloud-init network configuration remains
      disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)