### PR TITLE
Remove rook from ceph_stack options

### DIFF
--- a/testbed-default/variables.tf
+++ b/testbed-default/variables.tf
@@ -142,9 +142,9 @@ variable "ceph_stack" {
   default = "ceph-ansible"
   validation {
     condition = (
-      can(regex("^(ceph-ansible|rook)$", var.ceph_stack))
+      can(regex("^(ceph-ansible)$", var.ceph_stack))
     )
-    error_message = "Invalid Ceph Stack provided. Options: ceph-ansible|rook"
+    error_message = "Invalid Ceph Stack provided. Options: ceph-ansible"
   }
 }
 


### PR DESCRIPTION
Rook is being removed as a Ceph deployment option across OSISM. Drop "rook" from the accepted values of the ceph_stack variable so that ceph-ansible is the only valid Ceph stack; a configuration still requesting "rook" now fails validation. The variable itself and the CEPH_STACK plumbing in manager.tf are kept for ceph-ansible.

Part of osism/issues#1398.

Assisted-by: Claude:claude-opus-4-8