### PR TITLE
ceph: remove rook as ceph_stack option

### DIFF
--- a/testbed-default/manager.tf
+++ b/testbed-default/manager.tf
@@ -111,8 +111,6 @@ write_files:
       export IMAGE_USER=${var.image_user}
       export IMAGE_NODE_USER=${var.image_node_user}
 
-      export CEPH_STACK=${var.ceph_stack}
-
     path: /opt/manager-vars.sh
     permissions: '0644'
 runcmd:

--- a/testbed-default/variables.tf
+++ b/testbed-default/variables.tf
@@ -137,17 +137,6 @@ variable "external_api" {
   default = false
 }
 
-variable "ceph_stack" {
-  type    = string
-  default = "ceph-ansible"
-  validation {
-    condition = (
-      can(regex("^(ceph-ansible|rook)$", var.ceph_stack))
-    )
-    error_message = "Invalid Ceph Stack provided. Options: ceph-ansible|rook"
-  }
-}
-
 variable "deploy_mode" {
   type    = string
   default = "manager"


### PR DESCRIPTION
## What

Remove the `ceph_stack` variable and the `CEPH_STACK` export from the
`testbed-default` terraform blueprint. `ceph-ansible` becomes the single,
implicit Ceph stack.

## Why

The testbed dropped rook as a Ceph deployment option: every consumer of
`CEPH_STACK` now runs `ceph-ansible` unconditionally. That left this blueprint
as the last place advertising a `rook` value nothing honors — `ceph_stack=rook`
would still pass validation and get baked into `/opt/manager-vars.sh`, then
silently deploy `ceph-ansible` instead of the requested stack. With no consumer
left, the variable and its export are dead plumbing.

## Changes

- `testbed-default/variables.tf`: drop the `ceph_stack` variable (and its
  `^(ceph-ansible|rook)$` validation).
- `testbed-default/manager.tf`: drop the `export CEPH_STACK=${var.ceph_stack}`
  line from the manager cloud-init.

## Related

- osism/testbed#2919

🤖 Generated with [Claude Code](https://claude.com/claude-code)